### PR TITLE
Bump goenv to v0.0.3.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,5 +15,5 @@ class go::params {
     }
   }
 
-  $goenv_version = 'v0.0.2'
+  $goenv_version = 'v0.0.3'
 }

--- a/spec/classes/go_spec.rb
+++ b/spec/classes/go_spec.rb
@@ -12,7 +12,7 @@ describe "go" do
     })
 
     should contain_repository("/test/boxen/goenv").with({
-      :ensure => "v0.0.2",
+      :ensure => "v0.0.3",
       :source => "wfarr/goenv",
       :user   => "testuser"
     })


### PR DESCRIPTION
Includes GOROOT fix (wfarr/goenv#1).
