### PR TITLE
Update to work with latest versions of Go

### DIFF
--- a/manifests/1_2.pp
+++ b/manifests/1_2.pp
@@ -1,0 +1,5 @@
+# Public: Install Go 1.2
+
+class go::1_2 {
+  go::version { '1.2': }
+}

--- a/manifests/1_2_1.pp
+++ b/manifests/1_2_1.pp
@@ -1,0 +1,5 @@
+# Public: Install Go 1.2.1
+
+class go::1_2_1 {
+  go::version { '1.2.1': }
+}

--- a/manifests/1_2_2.pp
+++ b/manifests/1_2_2.pp
@@ -1,0 +1,5 @@
+# Public: Install Go 1.2.2
+
+class go::1_2_2 {
+  go::version { '1.2.2': }
+}

--- a/manifests/1_3.pp
+++ b/manifests/1_3.pp
@@ -1,0 +1,5 @@
+# Public: Install Go 1.3
+
+class go::1_3 {
+  go::version { '1.3': }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,7 @@ class go(
   $chgo_root    = $go::params::chgo_root,
   $chgo_user    = $go::params::chgo_user,
   $chgo_version = $go::params::chgo_version,
+  $chgo_source  = $go::params::chgo_source,
   $auto_switch  = $go::params::auto_switch,
 
   $goenv_root   = $go::params::goenv_root,
@@ -38,7 +39,7 @@ class go(
   repository { $chgo_root:
     ensure => $chgo_version,
     force  => true,
-    source => 'wfarr/chgo',
+    source => $chgo_source,
     user   => $chgo_user,
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,4 +20,5 @@ class go::params {
   $auto_switch  = true
 
   $chgo_version = 'v0.1.1'
+  $chgo_source  = 'wfarr/chgo'
 }


### PR DESCRIPTION
- Adds manifests for `1.2`, `1.2.1`, `1.2.2` and `1.3` (bringing in @dgoodlad's _1.x_ branch)
- Makes chgo source repository configurable through hiera

Currently go 1.2+ can't be installed through this module as we're missing a couple of manifests, and the download links for Go changed, which breaks [wfarr/chgo](https://github.com/wfarr/chgo).

I've fixed the problems in wfarr/chgo#6 so that all versions can be installed though this, but as this module has a hard coded reference to the repository, we have no way to get that fix in Boxen. So I've changed the source repository for chgo to be configurable, and we can then override this using hiera.

For example, to pull in the fixed chgo from my fork, you could add this to your hiera config (defaults to `hiera/common.yaml`):

``` yaml
go::chgo_source: "mattheath/chgo"
go::chgo_version: "3f0fb76a1eea09263011e3ad7d165bc525326de7"
```
