### PR TITLE
avoid creating classes just for golang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 script: "./script/cibuild"
+before_install: gem install bundler
 gemfile: "this/does/not/exist"
 rvm:
   - "1.8.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.4)
+    CFPropertyList (2.2.8)
+    addressable (2.3.6)
     ansi (1.4.3)
     boxen (1.2.1)
       ansi (~> 1.4)
@@ -16,23 +17,24 @@ GEM
       puppet-lint (~> 0.3)
       puppetlabs_spec_helper (~> 0.4)
       rspec-puppet (~> 0.1)
-    diff-lcs (1.2.4)
-    facter (1.7.1)
+    diff-lcs (1.2.5)
+    facter (2.3.0)
+      CFPropertyList (~> 2.2.6)
     faraday (0.8.7)
       multipart-post (~> 1.1)
     faraday_middleware (0.9.0)
       faraday (>= 0.7.4, < 0.9)
     hashie (2.0.5)
-    hiera (1.2.1)
+    hiera (1.3.4)
       json_pure
-    highline (1.6.19)
-    json (1.8.0)
-    json_pure (1.8.0)
+    highline (1.6.21)
+    json (1.8.1)
+    json_pure (1.8.1)
     librarian-puppet (0.9.9)
       json
       thor (~> 0.15)
-    metaclass (0.0.1)
-    mocha (0.14.0)
+    metaclass (0.0.4)
+    mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.7.3)
     multipart-post (1.2.0)
@@ -44,27 +46,36 @@ GEM
       hashie (~> 2.0)
       multi_json (~> 1.3)
       netrc (~> 0.7.7)
-    puppet (3.1.1)
-      facter (~> 1.6)
+    puppet (3.7.3)
+      facter (> 1.6, < 3)
       hiera (~> 1.0)
+      json_pure
     puppet-lint (0.3.2)
-    puppetlabs_spec_helper (0.4.1)
-      mocha (>= 0.10.5)
+    puppet-syntax (1.3.0)
       rake
-      rspec (>= 2.9.0)
-      rspec-puppet (>= 0.1.1)
-    rake (10.0.4)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    puppetlabs_spec_helper (0.8.2)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec
+      rspec-puppet
+    rake (10.4.2)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
     rspec-puppet (0.1.6)
       rspec
-    thor (0.18.1)
+    rspec-support (3.1.2)
+    thor (0.19.1)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ include go
 
 go::version { '1.1.1': }
 
-include go::1_1
+class { 'go::global' :
+  version => '1.1.1'
+}
 
 go::local { '/path/to/whatever':
   version => '1.1.1'

--- a/manifests/1_1.pp
+++ b/manifests/1_1.pp
@@ -1,5 +1,0 @@
-# Public: Install Go 1.1
-
-class go::1_1 {
-  go::version { '1.1': }
-}

--- a/manifests/1_1_1.pp
+++ b/manifests/1_1_1.pp
@@ -1,5 +1,0 @@
-# Public: Install Go 1.1.1
-
-class go::1_1_1 {
-  go::version { '1.1.1': }
-}

--- a/manifests/1_2.pp
+++ b/manifests/1_2.pp
@@ -1,5 +1,0 @@
-# Public: Install Go 1.2
-
-class go::1_2 {
-  go::version { '1.2': }
-}

--- a/manifests/1_2_1.pp
+++ b/manifests/1_2_1.pp
@@ -1,5 +1,0 @@
-# Public: Install Go 1.2.1
-
-class go::1_2_1 {
-  go::version { '1.2.1': }
-}

--- a/manifests/1_2_2.pp
+++ b/manifests/1_2_2.pp
@@ -1,5 +1,0 @@
-# Public: Install Go 1.2.2
-
-class go::1_2_2 {
-  go::version { '1.2.2': }
-}

--- a/manifests/1_3.pp
+++ b/manifests/1_3.pp
@@ -1,5 +1,0 @@
-# Public: Install Go 1.3
-
-class go::1_3 {
-  go::version { '1.3': }
-}

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -3,8 +3,7 @@
 # Usage: go::global { '1.9.0': }
 class go::global($version = '1.1.1') {
   require go
-  $klass = join(['go', join(split($version, '[.]'), '_')], '::')
-  require $klass
+  ensure_resource('go::version', $version, {ensure => present})
 
   file { "${go::chgo_root}/version":
     content => "${version}\n",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ class go(
       'chgo_auto':
         ensure   => $chgo_auto_ensure,
         content  => "source \$CHGO_ROOT/share/chgo/auto.sh\n",
-        priority => 99 ;
+        priority => 'lowest' ;
     }
   }
 

--- a/manifests/local.pp
+++ b/manifests/local.pp
@@ -12,8 +12,7 @@ define go::local($version = undef, $ensure = present) {
   validate_absolute_path($name)
 
   if $ensure == present {
-    $klass = join(['go', join(split($version, '[.]'), '_')], '::')
-    require $klass
+    ensure_resource('go::version', $version, {ensure => present})
   }
 
   file { "${name}/.go-version":

--- a/spec/classes/go__global_spec.rb
+++ b/spec/classes/go__global_spec.rb
@@ -1,19 +1,19 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "go::global" do
+describe 'go::global' do
   let(:facts) { default_test_facts }
   let(:params) do
     {
-      :version => "1.1.1"
+      :version => '1.3.3'
     }
   end
 
   it do
-    should include_class("go")
-    should include_class("go::1_1_1")
+    should include_class('go')
+    should contain_go__version('1.3.3')
 
-    should contain_file("/test/boxen/chgo/version").with({
-      :content => "1.1.1\n",
+    should contain_file('/test/boxen/chgo/version').with({
+      :content => "1.3.3\n",
     })
   end
 end

--- a/spec/classes/go_spec.rb
+++ b/spec/classes/go_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe "go" do
   let(:facts) { default_test_facts }
+  let(:params) { {:chgo_version => 'v0.1.0'} }
 
   it do
     should include_class("boxen::config")

--- a/spec/defines/go__local_spec.rb
+++ b/spec/defines/go__local_spec.rb
@@ -1,35 +1,35 @@
-require "spec_helper"
+require 'spec_helper'
 
-describe "go::local" do
+describe 'go::local' do
   let(:default_params) do
     {
-      :ensure  => "present",
-      :version => "1.1.1"
+      :ensure  => 'present',
+      :version => '1.1.1'
     }
   end
 
   let(:facts) { default_test_facts }
-  let(:title) { "/path/to/wherever" }
+  let(:title) { '/path/to/wherever' }
   let(:params) { default_params }
 
   it do
-    should include_class("go::1_1_1")
+    should contain_go__version('1.1.1')
 
-    should contain_file("/path/to/wherever/.go-version").with({
-      :ensure  => "present",
+    should contain_file('/path/to/wherever/.go-version').with({
+      :ensure  => 'present',
       :content => "1.1.1\n",
       :replace => true
     })
   end
 
   context "ensure => absent" do
-    let(:params) { default_params.merge(:ensure => "absent") }
+    let(:params) { default_params.merge(:ensure => 'absent') }
 
     it do
-      should_not include_class("go::1_1_1")
+      should_not include_class('go::version')
 
-      should contain_file("/path/to/wherever/.go-version").with({
-        :ensure => "absent"
+      should contain_file('/path/to/wherever/.go-version').with({
+        :ensure => 'absent'
       })
     end
   end

--- a/spec/defines/go__version_spec.rb
+++ b/spec/defines/go__version_spec.rb
@@ -14,7 +14,7 @@ describe "go::version" do
     should include_class("go")
 
     should contain_exec("chgo install 1.2.3").with({
-      :command  => "source /test/boxen/chgo/share/chgo/chgo.sh && chgo install 1.2.3",
+      :command  => "source /test/boxen/chgo/share/chgo/chgo.sh && chgo_install 1.2.3",
       :creates  => "/test/boxen/chgo/versions/1.2.3",
       :provider => "shell",
       :user     => "testuser"


### PR DESCRIPTION
Currently, the module is polluted with "version classes" like `go::1.2.1` which have one line `go::version` statements. This pr remove the needs for those classes.
Thanks
